### PR TITLE
Add bzip2 to the default packages

### DIFF
--- a/deploybot/php7/Dockerfile
+++ b/deploybot/php7/Dockerfile
@@ -5,7 +5,7 @@ RUN cd /tmp && \
 	bash setup_6.x && \
 	/usr/bin/apt-get install -y nodejs git zlib1g-dev && \
 	npm -g install yarn gulp && \
-	docker-php-ext-install zip
+	docker-php-ext-install zip bzip2
 
 # Register the COMPOSER_HOME environment variable
 ENV COMPOSER_HOME /composer


### PR DESCRIPTION
This is required to properly extract the phantomjs-prebuilt npm package, as discovered in https://github.com/Medium/phantomjs/issues/659.

Obligatory:
![GYAHHHh.tar.gz](http://i.imgur.com/Vf0An8J.png)